### PR TITLE
Whitelist error channel and OwO CMD

### DIFF
--- a/src/commands/settings.js
+++ b/src/commands/settings.js
@@ -11,6 +11,7 @@ const editableOptions = [
 	'stats_members_channel_id',
 	'stats_people_channel_id',
 	'stats_bots_channel_id',
+	'error_channel_id'
 ];
 
 async function verifyInputtedKey(interaction) {

--- a/src/database.js
+++ b/src/database.js
@@ -20,6 +20,7 @@ async function connect() {
 		stats_members_channel_id TEXT,
 		stats_people_channel_id TEXT,
 		stats_bots_channel_id TEXT,
+		error_channel_id TEXT,
 		UNIQUE(guild_id)
 	)`);
 


### PR DESCRIPTION
Made it so you'll have to whitelist a specific channel to send errors, to prevent clogging up other channels with errors replies, as suggested by Ceris.

Also yes, added an OWO-ifier, which is only accessible to people with the Developer role, just to make dev-offtopic much spicier!