### PR TITLE
Better automatic help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 config.json
 db.json
 database.db
+network-dumps-tmp

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,14 @@
         "@discordjs/builders": "^1.3.0",
         "@discordjs/rest": "^1.3.0",
         "@napi-rs/canvas": "^0.1.40",
+        "axios": "^1.4.0",
         "cld": "^2.9.0",
         "discord-api-types": "^0.31.2",
         "discord-html-transcripts": "^3.1.2",
         "discord.js": "^14.8.0",
         "fs-extra": "^10.1.0",
-        "languagedetect": "^2.0.0",
+        "lookpath": "^1.2.2",
         "natural": "^6.5.0",
-        "node-nlp": "^4.24.0",
         "sqlite": "^4.1.2",
         "sqlite3": "^5.1.2"
       },
@@ -296,108 +296,6 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
-    "node_modules/@microsoft/recognizers-text": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.3.0.tgz",
-      "integrity": "sha512-0gUhtS/0qSF6veB3Olu55IuJ0Skwg4u1IbJX9KFj1QeK8z6cw69/p637IPD2NgXLlXCy2HEqLvUW/mgbDp3rWg==",
-      "engines": {
-        "node": ">=10.3.0"
-      }
-    },
-    "node_modules/@microsoft/recognizers-text-choice": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.3.0.tgz",
-      "integrity": "sha512-I2LQAJJ9TJthJYWZNzooJD6+5KUkr+H+m54XpjY+vKjR81DPVFUL/SWZVyv+cC7eePFwrDv3gUnkXYS+Lp0hmA==",
-      "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.0",
-        "grapheme-splitter": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=10.3.0"
-      }
-    },
-    "node_modules/@microsoft/recognizers-text-data-types-timex-expression": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.3.0.tgz",
-      "integrity": "sha512-REHUXmMUI1jL3b9v+aSdzKxLxRdejsfg9McYRxY3LW0Gu4UbwD7Q+K6mtSo40cwg8uh6fiV9GY8hDuKXHH6dVA==",
-      "engines": {
-        "node": ">=10.3.0"
-      }
-    },
-    "node_modules/@microsoft/recognizers-text-date-time": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.3.0.tgz",
-      "integrity": "sha512-bgw4TS726maTg53M6SQRHQOzOH0za0zmBWnnGo0wQdbDfK+bgq5aeDSD4k/HhXvfkOD6zzRd3+tG3Dqyp/kFaQ==",
-      "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.0",
-        "@microsoft/recognizers-text-number": "~1.3.0",
-        "@microsoft/recognizers-text-number-with-unit": "~1.3.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.tonumber": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.3.0"
-      }
-    },
-    "node_modules/@microsoft/recognizers-text-number": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.3.0.tgz",
-      "integrity": "sha512-KVFxvaXW9E7UkuF0EYCghvCn0u+N5L7bBXeP4IKB6fXkQd6GAZ9zNA2Acdm9lJzCRxcsBYFbRLcRMrPHwAa32w==",
-      "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.0",
-        "bignumber.js": "^7.2.1",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.sortby": "^4.7.0",
-        "lodash.trimend": "^4.5.1"
-      },
-      "engines": {
-        "node": ">=10.3.0"
-      }
-    },
-    "node_modules/@microsoft/recognizers-text-number-with-unit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.3.0.tgz",
-      "integrity": "sha512-FxBD1ZQLvr4c+ssVyqUjblg+i21GbzIsDEHd5VWon5wg+2qrqixlmP1mXsXG+iGRV3qqeZCtTFdqkwJ3MWhovA==",
-      "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.0",
-        "@microsoft/recognizers-text-number": "~1.3.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.last": "^3.0.0",
-        "lodash.max": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=10.3.0"
-      }
-    },
-    "node_modules/@microsoft/recognizers-text-sequence": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.3.0.tgz",
-      "integrity": "sha512-LXZ9AakClrdPVfEphCJFETjw6n8w/LwW1Yoj9ZKcGI9PGvH6RR+haS4GSZuHeMhEacmaa3NkzD+I44qYIvym8Q==",
-      "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.0",
-        "grapheme-splitter": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=10.3.0"
-      }
-    },
-    "node_modules/@microsoft/recognizers-text-suite": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.3.0.tgz",
-      "integrity": "sha512-uqG4vzy5N2CmBaeINny0bLdnGp0jDbT1moNoLC+Yim3G8kHOU9lpDfwA6VN6HTYaDM5854SNMEzLjJdS1TPFTw==",
-      "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.0",
-        "@microsoft/recognizers-text-choice": "~1.3.0",
-        "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.0",
-        "@microsoft/recognizers-text-date-time": "~1.3.0",
-        "@microsoft/recognizers-text-number": "~1.3.0",
-        "@microsoft/recognizers-text-number-with-unit": "~1.3.0",
-        "@microsoft/recognizers-text-sequence": "~1.3.0"
-      },
-      "engines": {
-        "node": ">=10.3.0"
-      }
-    },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.41",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.41.tgz",
@@ -556,528 +454,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@nlpjs/builtin-duckling": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-duckling/-/builtin-duckling-4.26.1.tgz",
-      "integrity": "sha512-3qkH955X2g5MXV1EqT3fTAT/lLEdiqqe5IgBDyr+MQB7FOV9R3YhqGIn3DFOl+TSm/tP5n/BAEptkTNn/TOpmQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/builtin-microsoft": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-microsoft/-/builtin-microsoft-4.26.1.tgz",
-      "integrity": "sha512-AODgzTcfYUf5Ozm00aQnHImDum7Idtl0F9dSPoaXpfj7rZqP8hPZ7iWwdGTAvISH/da2YhjPOU65QSYk2YpjFA==",
-      "dependencies": {
-        "@microsoft/recognizers-text-suite": "1.3.0",
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/core": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core/-/core-4.26.1.tgz",
-      "integrity": "sha512-M/PeFddsi3y7Z1piFJxsLGm5/xdMhcrpOsml7s6CTEgYo8iduaT30HDd61tZxDyvvJseU6uFqlXSn7XKkAcC1g=="
-    },
-    "node_modules/@nlpjs/core-loader": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core-loader/-/core-loader-4.26.1.tgz",
-      "integrity": "sha512-IiRtn65bdiUSQHy2kusco2fmhk39u2Mc2c5Fsm9+9EVG6BtJCmVEFU/btAzGDAmxEA/E4qKecaAT4LvcW6TPbA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/request": "^4.25.0"
-      }
-    },
-    "node_modules/@nlpjs/emoji": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/emoji/-/emoji-4.26.1.tgz",
-      "integrity": "sha512-Q0PoXwIvaB1bnRXK4U/YD7mrqaz29Yfed3s2au0iXl1bffUgoG+hs4GORCvyy7DFCCLlc9d5yDM3oLIX/ggZ+Q==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/evaluator": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/evaluator/-/evaluator-4.26.1.tgz",
-      "integrity": "sha512-WeUrC8qq7+V8Jhkkjc2yiXdzy9V0wbETv8/qasQmL0QmEuwBDJF+fvfl4z2vWpBb0vW07A8aNrFElKELzbpkdg==",
-      "dependencies": {
-        "escodegen": "^2.0.0",
-        "esprima": "^4.0.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-all": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.26.1.tgz",
-      "integrity": "sha512-UzRm1JRRAyQqilEOxQ2ySMOitKbhPk5iKYbjD8FREDcPjreUvDxVuQsYUOvYucmEyFcZU2U/TdJx+fX9/bcaKQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-ar": "^4.26.1",
-        "@nlpjs/lang-bn": "^4.26.1",
-        "@nlpjs/lang-ca": "^4.26.1",
-        "@nlpjs/lang-cs": "^4.26.1",
-        "@nlpjs/lang-da": "^4.26.1",
-        "@nlpjs/lang-de": "^4.26.1",
-        "@nlpjs/lang-el": "^4.26.1",
-        "@nlpjs/lang-en": "^4.26.1",
-        "@nlpjs/lang-es": "^4.26.1",
-        "@nlpjs/lang-eu": "^4.26.1",
-        "@nlpjs/lang-fa": "^4.26.1",
-        "@nlpjs/lang-fi": "^4.26.1",
-        "@nlpjs/lang-fr": "^4.26.1",
-        "@nlpjs/lang-ga": "^4.26.1",
-        "@nlpjs/lang-gl": "^4.26.1",
-        "@nlpjs/lang-hi": "^4.26.1",
-        "@nlpjs/lang-hu": "^4.26.1",
-        "@nlpjs/lang-hy": "^4.26.1",
-        "@nlpjs/lang-id": "^4.26.1",
-        "@nlpjs/lang-it": "^4.26.1",
-        "@nlpjs/lang-ja": "^4.26.1",
-        "@nlpjs/lang-ko": "^4.26.1",
-        "@nlpjs/lang-lt": "^4.26.1",
-        "@nlpjs/lang-ms": "^4.26.1",
-        "@nlpjs/lang-ne": "^4.26.1",
-        "@nlpjs/lang-nl": "^4.26.1",
-        "@nlpjs/lang-no": "^4.26.1",
-        "@nlpjs/lang-pl": "^4.26.1",
-        "@nlpjs/lang-pt": "^4.26.1",
-        "@nlpjs/lang-ro": "^4.26.1",
-        "@nlpjs/lang-ru": "^4.26.1",
-        "@nlpjs/lang-sl": "^4.26.1",
-        "@nlpjs/lang-sr": "^4.26.1",
-        "@nlpjs/lang-sv": "^4.26.1",
-        "@nlpjs/lang-ta": "^4.26.1",
-        "@nlpjs/lang-th": "^4.26.1",
-        "@nlpjs/lang-tl": "^4.26.1",
-        "@nlpjs/lang-tr": "^4.26.1",
-        "@nlpjs/lang-uk": "^4.26.1",
-        "@nlpjs/lang-zh": "^4.26.1",
-        "@nlpjs/language": "^4.25.0"
-      }
-    },
-    "node_modules/@nlpjs/lang-ar": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ar/-/lang-ar-4.26.1.tgz",
-      "integrity": "sha512-MUlVtabt9ltG7WyzCQpFJymLJlnEqp3mxhgN9JHyFH7oZMK3REvMovFfvEUAbfiYrJEv/BN5KKLL7yrvUeaHtg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-bn": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.26.1.tgz",
-      "integrity": "sha512-sim1iZKBDdehi/yBUKrLW51QvS9uB+sXW7lj+THVqBy5UsnEQvt4gzE0NsC873uJMh66vt2AlHkhzgPH0qH/nQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ca": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ca/-/lang-ca-4.26.1.tgz",
-      "integrity": "sha512-fD4R5tcAB0uYtNxSEF20b1KmF6nUQSbiJqrIUJI5yis4ObjCYRQnSh4bjVDKUKxyONjbD6L8EaK5GrY1/jkwFQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-cs": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.26.1.tgz",
-      "integrity": "sha512-CqI6VB8toaJ/MlP1D4K9BctA6GpZJhMKyEy+OX9xavDe4r4ao/SxlSaIYK3izK0k+J38lJWC5lXYGazfCdTGjA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-da": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-da/-/lang-da-4.26.1.tgz",
-      "integrity": "sha512-krI/ojeDSi329ENM/hLIsbUh1x4XRTKAbtPcbFxAY6XVhcSVoWPO7L77jFTL1NQeE1oGRFzGHaeC9hZJ8phVbA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-de": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.26.1.tgz",
-      "integrity": "sha512-HfZQwsE5FICq9taVZDiyktmdAePVF5948NM80et0d9mx43RWDFhHKQYgtJPwfQXtdCoQtOM5TOJ2FanGwzPeaA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-el": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-el/-/lang-el-4.26.1.tgz",
-      "integrity": "sha512-pcOvuSwPCXxI+2xNZZzM4V5pTRDntYoJi0SP/ic2nV4IPQ0nU2j16dYfg1HlvET/E6iN1VTqghrCaf10SMkDGA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-en": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en/-/lang-en-4.26.1.tgz",
-      "integrity": "sha512-GVoJpOjyk5TtBAqo/fxsiuuH7jXycyakGT0gw5f01u9lOmUnpJegvXyGff/Nb0j14pXcGHXOhmpWrcTrG2B0LQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-en-min": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-en-min": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.26.1.tgz",
-      "integrity": "sha512-1sJZ7dy7ysqzbsB8IklguvB88J8EPIv4XGVkZCcwecKtOw+fp5LAsZ3TJVmEf18iK1gD4cEGr7qZg5fpPxTpWQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-es": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.26.1.tgz",
-      "integrity": "sha512-fIPQt+WPcNdyxZOCMkOPlMb4Y1iE585QxjB9IAdFz8ZtVg7mc4dlv5f46ud7ppdMh84iLOuOdo6pzu2Cqm14lw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-eu": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-eu/-/lang-eu-4.26.1.tgz",
-      "integrity": "sha512-Ha8GHTbgQYd7dwHM8aWHDyxmbUNUcyu/5xlBKqqBOPxysDyZ6Ad0tvj0FmJBy6mYhqmFTPBnEAo69cfuFSqWIQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-fa": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.26.1.tgz",
-      "integrity": "sha512-qJCmNXgJZnfNXUnKnxvEGEzSFBdQT4XU7/rMxuFmSJqmQY7fH/Vsmi5CKF94VRBPOIV4ULlEJuLpUWHXRmOnVQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-fi": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fi/-/lang-fi-4.26.1.tgz",
-      "integrity": "sha512-W/rUcrzSh3KE07q2vOsssTpU1sbX32gbBzKPZfRJ2ZUF4afO+eHxmAywikXubP4kiU3JxVNLvXXEjuGD3SBUbA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-fr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.26.1.tgz",
-      "integrity": "sha512-LTA852atCJnHtKDmtjx/ui5AnvEIkrPx+MJQ2mB3gn8ko6i2UITnJgPmJE9Kej5bLasVZOAJvU/SrfXEmnPGOw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ga": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ga/-/lang-ga-4.26.1.tgz",
-      "integrity": "sha512-JsP1CZ8r3Jd6o/Az7cN3exz0HDP3FNYLzh4Vi6ksEkdKF0yCjJ9G5dXZYqS9qFIN5ffemWn29G4WRELY6QH/cQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-gl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.26.1.tgz",
-      "integrity": "sha512-y1NNu6NVy/6o5UNfihgg0WkSlVr4IvKA5W193CpRLZWS4FccQDmnFFhyYWRkshyDbgEsfsZ0Rs3BoE82+T2Ubg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-hi": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hi/-/lang-hi-4.26.1.tgz",
-      "integrity": "sha512-Fw9rXqF5l8q9etJG5uOlEFpnMVjQEWMaCIgQfEcA1yTvieSV8mpoSvQkEZl+DFhww+azareoJ7ZCkx0gJ9UDuQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-hu": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.26.1.tgz",
-      "integrity": "sha512-7dPUn5/ZpLZmsdRwO+dtORuMIiIpnsWbgSLIKdOLh8irhgUR+M2bYTfkdnKcrEcHzHPP8Svn7pU0xk7OKSUA1w==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-hy": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hy/-/lang-hy-4.26.1.tgz",
-      "integrity": "sha512-T2brpLGDJryAwWmjtnmY8Ot6ZUkCz+/nRR9/QM1PybvZIqOVLjJqA49bqjJfT5DMN89HbwC7I/15NTT0y09i1Q==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-id": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.26.1.tgz",
-      "integrity": "sha512-rVuIkYFKdltFhMT/a2ZxD9ovoZSVZF7OPuqYjTXW9xKd3Ff32yUrzcf/pHXlqmZOSltqOH3E5jZRRDkHvgUOjQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-it": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-it/-/lang-it-4.26.1.tgz",
-      "integrity": "sha512-BZA3QnfQGW91gYaybRmHnCAPBvQggtmHZJrAmuBZUKUS12HoQm8uybjw2fZO+vahEeUQceKNDISRcT1eLLijog==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ja": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.26.1.tgz",
-      "integrity": "sha512-QgkuJOkHguRFyfnckH2It5/Kg8zecnOMJsHxYeuDC4tBF7jL/5xqWis+679lYLsXtAkrG8+fjVcBbjyopP0KHg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "kuromoji": "^0.1.2"
-      }
-    },
-    "node_modules/@nlpjs/lang-ko": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ko/-/lang-ko-4.26.1.tgz",
-      "integrity": "sha512-Q0N8bLJJ829ILWCKH1UQWPSNyuLaEURAXCawkDju4pt33DBLcpqz9IzO9dnqiFc+fjSgVzZ7WMaLT18hXZQ9vg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-lt": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.26.1.tgz",
-      "integrity": "sha512-SeYZxRhdCy+ClQNnF/u0MAtcDui/ocdk4NtgNOCuwNTNuzhN3t3rfGeArfBGmZeg1SIeBLUDE9dsTxYCv5AOEg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ms": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ms/-/lang-ms-4.26.1.tgz",
-      "integrity": "sha512-KxWBS+tFY2U8z9UrjQIqMM40npGDOskP5DcWhaEE3zuhzf3RTDYjy8sdz34jVd0fBdbPihX133h3bFibg2Cm7w==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-id": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ne": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.26.1.tgz",
-      "integrity": "sha512-K3E2l+0LTESv+dO+ZTIdvNa+zwMJvvnMiFYYkKvJst6lhc8JgvGOsPxGsjJn6PDhI3wyfQu+dg3b+bnVPu4FDA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-nl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-nl/-/lang-nl-4.26.1.tgz",
-      "integrity": "sha512-I/mP1RRbUN4BQ+8NXAl2FKaLHbb7f6S8JVjxHQ0sKHT4BgQ3+r0yO+DVcEsHg+vWRiY1Fyzh0gq0PhLVnF6HnA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-no": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.26.1.tgz",
-      "integrity": "sha512-a0CLL2c/OCzbg7J7ugyrsAksI96XhkQ3IeBbbx60o5o/9wsFNik6cPWrkpoE5xNtw7gLlAJWabwDiZXkl8Zrcw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-pl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pl/-/lang-pl-4.26.1.tgz",
-      "integrity": "sha512-nrDXlq+TzQLE5IpXPIlFMzd8OpquvApWsouh6fmLsD9HZLZI4O3w1M4sXXLzE+9Ggu9Cy1m1QJ0/i7XCcv115g==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-pt": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.26.1.tgz",
-      "integrity": "sha512-p6yZHaJ0e+n0avMHpdDw5PMk4HkKXjPbOMbrlg0dF+VRqChjxfH478Q423rDyzu/4MzDsIYB+p6KzL9AARKXpg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ro": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ro/-/lang-ro-4.26.1.tgz",
-      "integrity": "sha512-baUdTA0DWpDR0Tn6fxo+RDN/6gbuINLCARtHwap2UR/HKQWP2XoH/DIvcjZpwUTalr5MQjso31epcdeRRapczA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ru": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.26.1.tgz",
-      "integrity": "sha512-NaZ2DAOGxWG2Us9IyIDs3m6vhGpUaUJRVgzzHHyX3LO3xEYjZmtnA0jEpBaTOe2PuNHThv0WCZUNn9BSurV3PA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-sl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sl/-/lang-sl-4.26.1.tgz",
-      "integrity": "sha512-QBJwcJt+oKUpAnHKNJkLkx9Xm1n4dUPC5GPYfAXTnJZf0hNWJSY21GicdWi7Vu/qFJ3ghIqtSP8D7KIPLnibNw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-sr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.26.1.tgz",
-      "integrity": "sha512-drH3+UqTW637uLWsnLrcp8jEKUGxV61ZgCBjNkVQNEv1/jbpSg6IqgynSY2JyhtnlV0f870KS0HvSbyo5AD4Ng==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-sv": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sv/-/lang-sv-4.26.1.tgz",
-      "integrity": "sha512-2axkrYFC02tAlxCWeiEKISbe4dSteciP1CIggO/dZglnnLWgdF+g7kOeYMn7abCfFVSnh5vLqfDkrwnyIqt7Ag==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ta": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.26.1.tgz",
-      "integrity": "sha512-keeh+croa1TAirV9Fd3OQMo5IkAlTGNWTNweHbi/htYMX0MKOPYxyqg+VH2bml+57VY2aUj/WYgV/p3ATx9EfQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-th": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-th/-/lang-th-4.26.1.tgz",
-      "integrity": "sha512-2SWZhrln3rMw8/DsRc9yS5bi3qEdGfw2pq9Uejx/UYED5zvvL6kh9AiCJZT4k0wMBGEwWUV6HxJ0Pq/jOTHogg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-tl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.26.1.tgz",
-      "integrity": "sha512-AzmLtg28tm0VXCm0Q0EY3OtA3m4oYxaqh4VX6uhB4J+PoEsIkm0py12SJxMNIsh/r98pobCumH8KH9bvHQoCAg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-tr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tr/-/lang-tr-4.26.1.tgz",
-      "integrity": "sha512-p30uuXvE9pZeU/5XkrQfvxRgiAOBmP3EyBFGV/+P05PEogaqbsmmtVCgCnR63yeRvVnGbToPBPjRK3OO1y4AEQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-uk": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.26.1.tgz",
-      "integrity": "sha512-PVEvmlhvl6BL3e/Q4qjMPsnwON3cWEYvDh9dg+Si+sjD2Edu9tajolJKcQ6ZA4I8dXrld5xuXx+DEBH/uB4uWQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-zh": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-zh/-/lang-zh-4.26.1.tgz",
-      "integrity": "sha512-kwqeqeEgMAMvucVX9HNE1p6s/2APP23ZsS8Um/lNvtswb4gL5jjYF9kyCvRfqlPBQSWWdRv7wwcnNXOvXYkxcQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/language": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language/-/language-4.25.0.tgz",
-      "integrity": "sha512-tUF6QENoUQ/E26RYc32IgsttStSF9cNO4ySN+BQECn8VpjukWdwbMw073MlOLXzjfeobxa+3hCVrmPPcW+V3UA=="
-    },
-    "node_modules/@nlpjs/language-min": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.25.0.tgz",
-      "integrity": "sha512-g8jtbDbqtRm+dlD/1Vnb4VWfKbKteApEGVTqIMxYkk6N/HMhvLZ5J2svrxzrB98a/HZ0fb//YBfFgymnz9Oukg=="
-    },
-    "node_modules/@nlpjs/ner": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.27.0.tgz",
-      "integrity": "sha512-ptwkxriJdmgHSH9TfP10JQ1jviaSl2SupSFGUvTuWkuJhobQd3hbnlSq40V6XYvJNmqh9M9zEab/AKeghxYOTA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/similarity": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/neural": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/neural/-/neural-4.25.0.tgz",
-      "integrity": "sha512-Oz20denGiBe0DlQsS7lN4TNrATN1nXlHKc/HB6jJPegjVmgJVCugDaHwIGoV7qOWyA6F2fRRwOgD+quNT2gVpg=="
-    },
-    "node_modules/@nlpjs/nlg": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.26.1.tgz",
-      "integrity": "sha512-PCJWiZ7464ChXXUGvjBZIFtoqkC24Oy6X63HgQrSv+63svz22Y5Cmu1MYLk77Nb+4keWv+hKhFJKDkvJoOpBVg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/nlp": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlp/-/nlp-4.27.0.tgz",
-      "integrity": "sha512-q6X7sY6TYVnQRZJKF/6mfLFlNA5oRYLhgQ5k3i1IBqH9lbWTAZJr31w/dCf97HXaYaj+vJp3h0ucfNumme9EIw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/ner": "^4.27.0",
-        "@nlpjs/nlg": "^4.26.1",
-        "@nlpjs/nlu": "^4.27.0",
-        "@nlpjs/sentiment": "^4.26.1",
-        "@nlpjs/slot": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/nlu": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.27.0.tgz",
-      "integrity": "sha512-j4DUdoXS/y/Xag6ysYXx7Ve8NBmUVViUSCJhj3r49+zGyYtyVAHuVcqSej5q0tJjn0JSMT+6+ip8klON1q8ixw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0",
-        "@nlpjs/similarity": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/request": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/request/-/request-4.25.0.tgz",
-      "integrity": "sha512-MPVYWfFZY03WyFL7GWkUkv8tw968OXsdxFSJEvjXHzhiCe/vAlPCWbvoR+VnoQTgzLHxs/KIF6sIF2s9AzsLmQ==",
-      "dependencies": {
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0"
-      }
-    },
-    "node_modules/@nlpjs/sentiment": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.26.1.tgz",
-      "integrity": "sha512-U2WmcW3w6yDDO45+Y7v5e6DPQj8e0x+RUUePPyRu2uIZmUtIKG+qCPMWnNLMmYQZoSQEFxmMMlLcGDC7tN7o3w==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0"
-      }
-    },
-    "node_modules/@nlpjs/similarity": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/similarity/-/similarity-4.26.1.tgz",
-      "integrity": "sha512-QutSBFGo/huNuz60PgqCjub0oBd9S8MLrjme33U5GzxuSvToQzXtn9/ynIia8qDm009D09VXV+LPeNE4h7yuSg=="
-    },
-    "node_modules/@nlpjs/slot": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.26.1.tgz",
-      "integrity": "sha512-mK8EEy5O+mRGne822PIKMxHSFh8j+iC7hGJ6T31XdFsNhFEYXLI/0dmeBstZgTSKBTe27HNFgCCwuGb77u0o9w=="
-    },
-    "node_modules/@nlpjs/xtables": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/xtables/-/xtables-4.25.0.tgz",
-      "integrity": "sha512-+baCtMZIp+aDqODLQs8Wyyke5qUqQkL8AGWsZzwYuJV8S7xdW2+XklRnHnkFc3p3foC248TkzG5L8j9r6INOtg==",
-      "dependencies": {
-        "xlsx": "^0.18.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1185,14 +561,6 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@types/node": {
       "version": "20.4.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
@@ -1259,14 +627,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/afinn-165": {
@@ -1398,26 +758,25 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dependencies": {
-        "lodash": "^4.17.14"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/bignumber.js": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1477,18 +836,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1544,14 +891,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1578,6 +917,17 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comment-parser": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
@@ -1596,17 +946,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1648,6 +987,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -1743,11 +1090,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/doublearray": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
-      "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw=="
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1787,26 +1129,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -1929,18 +1251,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -1969,6 +1279,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -1977,6 +1288,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2070,12 +1382,36 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "engines": {
-        "node": ">=0.8"
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -2177,11 +1513,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2220,19 +1551,6 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "optional": true
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -2454,24 +1772,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/kuromoji": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
-      "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
-      "dependencies": {
-        "async": "^2.0.1",
-        "doublearray": "0.0.2",
-        "zlibjs": "^0.3.1"
-      }
-    },
-    "node_modules/languagedetect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/languagedetect/-/languagedetect-2.0.0.tgz",
-      "integrity": "sha512-AZb/liiQ+6ZoTj4f1J0aE6OkzhCo8fyH+tuSaPfSo8YHCWLFJrdSixhtO2TYdIkjcDQNaR4RmGaV2A5FJklDMQ==",
-      "engines": {
-        "node": ">= 0.4.8"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2505,26 +1805,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-    },
-    "node_modules/lodash.last": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
-      "integrity": "sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A=="
-    },
-    "node_modules/lodash.max": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
-      "integrity": "sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ=="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2536,20 +1816,16 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
-    },
-    "node_modules/lodash.tonumber": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
-      "integrity": "sha512-SY0SwuPOHRwKcCNTdsntPYb+Zddz5mDUIVFABzRMqmAiL41pMeyoQFGxYAw5zdc9NnH4pbJqiqqp5ckfxa+zSA=="
-    },
-    "node_modules/lodash.trimend": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
-      "integrity": "sha512-lsD+k73XztDsMBKPKvzHXRKFNMohTjoTKIIo4ADLn5dA65LZ1BqlAvSXhR2rPEC3BgAUQnzMnorqDtqn2z4IHA=="
+    "node_modules/lookpath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/lookpath/-/lookpath-1.2.2.tgz",
+      "integrity": "sha512-k2Gmn8iV6qdME3ztZC2spubmQISimFOPLuQKiPaLcVdRz0IpdxrNClVepMlyTJlhodm/zG/VfbkWERm3kUIh+Q==",
+      "bin": {
+        "lookpath": "bin/lookpath.js"
+      },
+      "engines": {
+        "npm": ">=6.13.4"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -2643,6 +1919,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -2888,28 +2183,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/node-nlp": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/node-nlp/-/node-nlp-4.27.0.tgz",
-      "integrity": "sha512-LnkhOUPXX0CMFbSzJ1gHI+7Yb3ULLip5gRsqedXb6pryjcRCbNzPgHXcH/6G9B1vSbDfO+y3X2B4QZpfP12OyQ==",
-      "dependencies": {
-        "@nlpjs/builtin-duckling": "^4.26.1",
-        "@nlpjs/builtin-microsoft": "^4.26.1",
-        "@nlpjs/core-loader": "^4.26.1",
-        "@nlpjs/emoji": "^4.26.1",
-        "@nlpjs/evaluator": "^4.26.1",
-        "@nlpjs/lang-all": "^4.26.1",
-        "@nlpjs/language": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0",
-        "@nlpjs/nlg": "^4.26.1",
-        "@nlpjs/nlp": "^4.27.0",
-        "@nlpjs/nlu": "^4.27.0",
-        "@nlpjs/request": "^4.25.0",
-        "@nlpjs/sentiment": "^4.26.1",
-        "@nlpjs/similarity": "^4.26.1",
-        "@nlpjs/xtables": "^4.25.0"
-      }
-    },
     "node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -3090,6 +2363,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -3368,15 +2646,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
@@ -3430,17 +2699,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
-    },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/ssri": {
       "version": "8.0.1",
@@ -3784,22 +3042,6 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/wordnet-db": {
       "version": "3.1.14",
       "resolved": "https://registry.npmjs.org/wordnet-db/-/wordnet-db-3.1.14.tgz",
@@ -3833,26 +3075,6 @@
         }
       }
     },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3868,14 +3090,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zlibjs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
-      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
-      "engines": {
-        "node": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "@discordjs/builders": "^1.3.0",
     "@discordjs/rest": "^1.3.0",
     "@napi-rs/canvas": "^0.1.40",
+    "axios": "^1.4.0",
     "cld": "^2.9.0",
     "discord-api-types": "^0.31.2",
     "discord-html-transcripts": "^3.1.2",
     "discord.js": "^14.8.0",
     "fs-extra": "^10.1.0",
+    "lookpath": "^1.2.2",
     "natural": "^6.5.0",
     "sqlite": "^4.1.2",
     "sqlite3": "^5.1.2"

--- a/src/commands/togglerole.js
+++ b/src/commands/togglerole.js
@@ -26,7 +26,7 @@ async function toggleroleHandler(interaction) {
 	}
 
 	const hasRole = member.roles.cache.has(role.id);
-	
+
 	if (hasRole) {
 		await member.roles.remove(role);
 	} else {

--- a/src/nlp/message-processor.js
+++ b/src/nlp/message-processor.js
@@ -6,8 +6,8 @@ const trainingDataDir = `${__dirname}/training-data`;
 
 class AIMessageProcessor {
 	constructor() {
-		this.classifierThreshold = 0.8;
-		this.cldThreshold = 80;
+		this.classifierThreshold = 1;
+		this.cldThreshold = 100;
 		this.classifiers = {};
 		this.answers = {};
 

--- a/src/utils/cooldown.js
+++ b/src/utils/cooldown.js
@@ -66,15 +66,15 @@ function getRelativeTime(timestamp) {
 	}
 
 	else if (elapsed < msPerMonth) {
-		return `in ${Math.round(elapsed/msPerDay)} day(s)`;   
+		return `in ${Math.round(elapsed/msPerDay)} day(s)`;
 	}
 
 	else if (elapsed < msPerYear) {
-		return `in ${Math.round(elapsed/msPerMonth)} month(s)`;   
+		return `in ${Math.round(elapsed/msPerMonth)} month(s)`;
 	}
 
 	else {
-		return `in ${Math.round(elapsed/msPerYear)} year(s)`;   
+		return `in ${Math.round(elapsed/msPerYear)} year(s)`;
 	}
 }
 

--- a/src/utils/network-dumps-converter.js
+++ b/src/utils/network-dumps-converter.js
@@ -1,0 +1,230 @@
+const path = require('node:path');
+const util = require('node:util');
+const { exec } = require('node:child_process');
+const querystring = require('node:querystring');
+const Discord = require('discord.js');
+const fs = require('fs-extra');
+const axios = require('axios');
+
+const execPromise = util.promisify(exec);
+
+// TODO - Are there more headers to scrub?
+const HEADERS_TO_SCRUB = [
+	'authorization',
+	'x-nintendo-serial-number',
+	'x-nintendo-device-cert',
+	'x-nintendo-servicetoken',
+];
+
+/**
+ *
+ * @param {Discord.Message} message
+ */
+async function networkDumpsConverter(message) {
+	const filesToRemove = [];
+
+	// * Check if the message has any proxy dumps
+	// * Charles technically supports pcap dumps too but I've never gotten them to work
+	const networkDumps = [...message.attachments.filter(attachment => {
+		const fileExtension = path.extname(attachment.name.toLowerCase());
+		if (
+			fileExtension === '.har' ||   // * HTTP Archive dump
+			fileExtension === '.chls' ||  // * Charles session
+			fileExtension === '.chlsj' || // * Charles JSON summary
+			fileExtension === '.chlsx' || // * Charles XML summary
+			fileExtension === '.saz'      // * Fiddler session
+		) {
+			return attachment;
+		}
+	}).values()];
+
+	if (networkDumps.length === 0) {
+		return;
+	}
+
+	const attachmentsToConvert = [];
+
+	// * Download all the dumps
+	for (const attachment of networkDumps) {
+		const fileExtension = path.extname(attachment.name.toLowerCase());
+		const downloadPath = `${__dirname}/../../network-dumps-tmp/${attachment.id}${fileExtension}`;
+
+		filesToRemove.push(downloadPath);
+
+		const response = await axios({
+			method: 'get',
+			url: attachment.url,
+			responseType: 'stream'
+		});
+
+		await new Promise((resolve, reject) => {
+			const writeStream = fs.createWriteStream(downloadPath);
+			response.data.on('end', resolve);
+			writeStream.on('error', reject);
+
+			response.data.pipe(writeStream);
+		});
+
+		attachmentsToConvert.push(attachment);
+	}
+
+	const embed = new Discord.EmbedBuilder();
+	embed.setColor(0x00FF22);
+	embed.setFields(networkDumps.map(attachment => {
+		const fileExtension = path.extname(attachment.name.toLowerCase());
+		let type = '';
+
+		switch (fileExtension) {
+			case '.har':
+				type = 'HAR (HTTP Archive dump)';
+				break;
+			case '.chls':
+				type = 'chls (Charles session)';
+				break;
+			case '.chlsj':
+				type = 'chlsj (Charles JSON summary)';
+				break;
+			case '.chlsx':
+				type = 'chlsx (Charles XML summary)';
+				break;
+			case '.saz':
+				type = 'saz (Fiddler session)';
+				break;
+		}
+
+		return {
+			name: type,
+			value: attachment.name
+		};
+	}));
+
+	await message.channel.send({
+		content: `<@${message.author.id}> I have detected the following network dumps in your message. For security reasons, your dumps will be scrubbed of user information. Your message will be deleted until this process is complete`,
+		embeds: [embed],
+		ephemeral: true
+	});
+
+	await message.delete();
+
+	const convertedNetworkDumps = [];
+
+	await fs.ensureDir(`${__dirname}/../../network-dumps-tmp`);
+
+	// * Convert and process the downloaded dumps
+	// * This can be slow
+	for (const attachment of attachmentsToConvert) {
+		const fileExtension = path.extname(attachment.name.toLowerCase());
+		const downloadPath = `${__dirname}/../../network-dumps-tmp/${attachment.id}${fileExtension}`;
+
+		const charlesJSONSummaryPath = `${__dirname}/../../network-dumps-tmp/${attachment.id}.chlsj`;
+
+		filesToRemove.push(charlesJSONSummaryPath);
+
+		if (fileExtension !== '.chlsj') {
+			await execPromise(`charles convert ${downloadPath} ${charlesJSONSummaryPath}`);
+		}
+
+		const charlesJSONSummary = await fs.readJSON(charlesJSONSummaryPath);
+
+		// TODO - Are there more requests/responses to scrub?
+		for (const { request, response, path: requestPath } of charlesJSONSummary) {
+			for (const header of request.header.headers) {
+				if (HEADERS_TO_SCRUB.includes(header.name.toLowerCase())) {
+					header.value = 'REMOVED';
+				}
+			}
+
+			for (const header of response.header.headers) {
+				if (HEADERS_TO_SCRUB.includes(header.name.toLowerCase())) {
+					header.value = 'REMOVED';
+				}
+			}
+
+			// * Remove NNID/PNID password and refresh token from request
+			// * Remove access and refresh token from response
+			if (requestPath === '/v1/api/oauth20/access_token/generate') {
+				const newRequestBody = querystring.parse(request.body.text);
+
+				if (newRequestBody.password) {
+					newRequestBody.password = 'REMOVED';
+				}
+
+				if (newRequestBody.refresh_token) {
+					newRequestBody.refresh_token = 'REMOVED';
+				}
+
+				request.body.text = querystring.stringify(newRequestBody);
+
+				response.body.text = response.body.text.replace(/<token>.*<\/token>/, '<token>REMOVED</token>');
+				response.body.text = response.body.text.replace(/<refresh_token>.*<\/refresh_token>/, '<refresh_token>REMOVED</refresh_token>');
+			}
+
+			// * Remove birthday and email address from account details
+			if (requestPath === '/v1/api/people/@me/profile') {
+				response.body.text = response.body.text.replace(/<address>.*<\/address>/, '<address>removed@email.com</address>');
+				response.body.text = response.body.text.replace(/<birth_date>.*<\/birth_date>/, '<birth_date>YYYY-MM-DD</birth_date>');
+			}
+
+			// * Remove service token
+			if (requestPath === '/v1/api/provider/service_token/@me') {
+				response.body.text = response.body.text.replace(/<token>.*<\/token>/, '<token>REMOVED</token>');
+			}
+
+			// * Remove NEX token and password
+			if (requestPath === '/v1/api/provider/nex_token/@me') {
+				response.body.text = response.body.text.replace(/<token>.*<\/token>/, '<token>REMOVED</token>');
+				response.body.text = response.body.text.replace(/<nex_password>.*<\/nex_password>/, '<nex_password>REMOVED</nex_password>');
+			}
+		}
+
+		await fs.writeFile(charlesJSONSummaryPath, JSON.stringify(charlesJSONSummary));
+
+		const harPath = `${__dirname}/../../network-dumps-tmp/${attachment.id}.har`;
+
+		filesToRemove.push(harPath);
+
+		await execPromise(`charles convert ${charlesJSONSummaryPath} ${harPath}`);
+
+		const oldFileName = attachment.url.split('/').pop();
+		const fileNameParts = oldFileName.split('.');
+
+		fileNameParts.pop();
+		fileNameParts.push('har');
+
+		convertedNetworkDumps.push({
+			attachment: harPath,
+			name: fileNameParts.join('.')
+		});
+	}
+
+	const embeds = [];
+
+	if (message.content) {
+		const embed = new Discord.EmbedBuilder();
+		embed.setColor(0x00FF22);
+		embed.setAuthor({
+			iconURL: message.author.displayAvatarURL(),
+			name: message.author.username
+		});
+		embed.setDescription(message.content);
+
+		embeds.push(embed);
+	}
+
+	await message.channel.send({
+		content: `<@${message.author.id}> Uploaded network dumps. For security reasons, the original message has been deleted and scrubbed versions of the dumps are attached below. All dumps have been converted to HAR for standardization`,
+		embeds: embeds,
+		files: convertedNetworkDumps
+	});
+
+	// * Clean up
+	for (const file of filesToRemove) {
+		if (await fs.exists(file)) {
+			await fs.remove(file);
+		}
+	}
+}
+
+module.exports = {
+	networkDumpsConverter
+};

--- a/src/utils/polls.js
+++ b/src/utils/polls.js
@@ -146,7 +146,7 @@ async function closePoll(message) {
 	const attachment = new Discord.AttachmentBuilder(pollImage, {
 		name: 'image.png',
 	});
-    
+
 	message.edit({
 		files: [attachment],
 		components: []


### PR DESCRIPTION
Draft because @gitlimes wants me to change this due to some security concerns

PR makes changes to the `AIMessageProcessor` class to increase the thresholds, as well as adds the ability for Bandwidth to scrub and convert common proxy server dumps

The changes made to the `AIMessageProcessor` are done because Bandwidth's AI is still not perfect, and would result in false positives. Setting the thresholds to perfect scores essentially disables the feature for now until we have time to sit down and improve it. These changes were already in Bandwidth by changing the values on the server with `nano`, this just brings them into the repo now

Bandwidth now scans messages for attachments containing common proxy server dumps. It does this via the attachments extension. Bandwidth will then download said file and use the `charles` CLI tool to convert them into JSON summaries, scrub them of personal information and then upload them again converted to HAR

The following data is removed

## Headers
- `authorization`
- `x-nintendo-serial-number`
- `x-nintendo-device-cert`
- `x-nintendo-servicetoken`

## account.nintendo.net / account.pretendo.cc
### `/v1/api/oauth20/access_token/generate`
- `password` from the request
- `refresh_token` from the request
- `token` from the response
- `refresh_token` from the response

### `/v1/api/people/@me/profile`
- Email address from the response
- Birthday from the response

### `/v1/api/provider/service_token/@me`
- `token` from the response

### `/v1/api/provider/nex_token/@me`
- `token` from the response
- `nex_password` from the response

## nasc.nintendowifi.net / nasc.pretendo.cc
### `/ac`
- `fcdcert` from the request. Contains your LocalFriendCodeSeed_B
- `csnum` from the request. Serial number
- `macadr` from the request. MAC address
- `bssid` from the request
- `passwd` from the request. This is the NEX password the console wants to use. Only sent when the console is registering a new NEX account (like after a factory reset)
- `token` from the response. Only seen if requesting a NEX token
- `servicetoken` from the response. Only seen if requesting a service token