### PR TITLE
Add localization to Bandwidth errors

### DIFF
--- a/src/buttons/expand-error.js
+++ b/src/buttons/expand-error.js
@@ -18,7 +18,7 @@ async function expandErrorHandler(interaction) {
 	const ogButton = message.components[0];
 
 	// Grab that error code again
-	const errorCodeEmbed = errorCodeUtils.checkForErrorCode(message.embeds[0].title);
+	const errorCodeEmbed = errorCodeUtils.checkForErrorCode(message.embeds[0].title, interaction.locale);
 
 	// Swap the embed out, while removing our button component
 	message.edit({

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -57,7 +57,7 @@ async function messageCreateHandler(message) {
  * @param {Discord.Message} message
  */
 async function tryAutomaticHelp(message) {
-	const errorCodeEmbed = errorCodeUtils.checkForErrorCode(message.content);
+	const errorCodeEmbed = errorCodeUtils.checkForErrorCode(message.content, 'en-US');
 	const row = new Discord.ActionRowBuilder();
 
 	if (errorCodeEmbed) {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -167,5 +167,16 @@
                 "link": "Missing link"
             }
         }
+    },
+    "3ds": {
+        "000": {
+            "0000": {
+                "name": "Missing name",
+                "description": "Missing description",
+                "message": "An error has occurred.\nPlease try again later.\n\nIf the problem persists, please\nmake a note of the error code and\nvisit support.nintendo.com.",
+                "fix": "Missing fix",
+                "link": "Missing link"
+            }
+        }
     }
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1,0 +1,171 @@
+{
+    "pretendo": {
+        "598": {
+            "0000": {
+                "name": "598-0000",
+                "description": "Generic network error",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0001": {
+                "name": "598-0001",
+                "description": "Cannot like own post",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0002": {
+                "name": "598-0002",
+                "description": "Cannot follow community\nUser either already following it or the database may not be available",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0003": {
+                "name": "598-0003",
+                "description": "Cannot Follow User",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0004": {
+                "name": "598-0004",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0005": {
+                "name": "598-0005",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0006": {
+                "name": "598-0006",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0007": {
+                "name": "598-0007",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0008": {
+                "name": "598-0008",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0009": {
+                "name": "598-0009",
+                "description": "User limited from posting",
+                "message": null,
+                "fix": "Contact a moderator to appeal",
+                "link": null
+            },
+            "0010": {
+                "name": "598-0010",
+                "description": "User temporary banned",
+                "message": null,
+                "fix": "Contact a moderator to appeal",
+                "link": null
+            },
+            "0011": {
+                "name": "598-0011",
+                "description": "User permanently banned",
+                "message": null,
+                "fix": "Contact a moderator to appeal",
+                "link": null
+            },
+            "0012": {
+                "name": "598-0012",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0013": {
+                "name": "598-0013",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0014": {
+                "name": "598-0014",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0015": {
+                "name": "598-0015",
+                "description": "Background application does not support screenshots",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0016": {
+                "name": "598-0016",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0017": {
+                "name": "598-0017",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0018": {
+                "name": "598-0018",
+                "description": "Background application does not support screenshots",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0019": {
+                "name": "598-0019",
+                "description": "N/A",
+                "message": null,
+                "fix": "N/A",
+                "link": null
+            },
+            "0020": {
+                "name": "598-0020",
+                "description": "Service token present, unable to parsed (likely a Nintendo Network Account)",
+                "message": null,
+                "fix": "Check if you are logging into a PNID and ran the patcher",
+                "link": null
+            }
+        }
+    },
+    "wiiu": {
+        "102": {
+            "2482": {
+                "name": "INVALID_GAME_SERVER_ID",
+                "description": "The game server requested could not be found. Either the game is not supported or is not available in your account environment",
+                "message": "Missing message",
+                "fix": "Check to see if your game is supported at https://pretendo.network/progress. If it is, check your server environment setting at https://pretendo.network/account",
+                "link": "Missing link"
+            },
+            "9999": {
+                "name": "Missing name",
+                "description": "Missing description",
+                "message": "An error has occurred.\n\nPlease try again later.\n\nIf the problem persists, please\nmake a note of the error code and\nvisit support.nintendo.com.",
+                "fix": "Missing fix",
+                "link": "Missing link"
+            }
+        }
+    }
+}

--- a/src/utils/errorCode.js
+++ b/src/utils/errorCode.js
@@ -12,24 +12,27 @@ const PRETENDO_SUPPORT_CODE_REGEX = /(\b678-\d{4}\b|\b598-\d{4}\b)/gm; // * 678 
  *
  * @param {String}} message
  */
-function checkForErrorCode(text) {
+function checkForErrorCode(text, locale) {
+	// Grab Locales
+	const localeJSON = require(`../locales/${locale}.json`);
+	
 	// TODO - WiiU error codes, 3DS error codes
 
 	// * Run this check first to avoid WiiU conflicts
 	if (PRETENDO_SUPPORT_CODE_REGEX.test(text)) {
-		return getPretendoSupportCodeInfo(text.match(PRETENDO_SUPPORT_CODE_REGEX)[0]);
+		return getPretendoSupportCodeInfo(text.match(PRETENDO_SUPPORT_CODE_REGEX)[0], localeJSON);
 	}
 
 	if (WIIU_SUPPORT_CODE_REGEX.test(text)) {
-		return getWiiUSupportCodeInfo(text.match(WIIU_SUPPORT_CODE_REGEX)[0]);
+		return getWiiUSupportCodeInfo(text.match(WIIU_SUPPORT_CODE_REGEX)[0], localeJSON);
 	}
 
 	if (THREE_DS_SUPPORT_CODE_REGEX.test(text)) {
-		return get3DSSupportCodeInfo(text.match(THREE_DS_SUPPORT_CODE_REGEX)[0]);
+		return get3DSSupportCodeInfo(text.match(THREE_DS_SUPPORT_CODE_REGEX)[0], localeJSON);
 	}
 }
 
-function getWiiUSupportCodeInfo(supportCode) {
+function getWiiUSupportCodeInfo(supportCode, localeJSON) {
 	const [moduleId, descriptionId] = supportCode.split('-');
 
 	const mod = wiiuSupportCodes[moduleId]; // * `module` is reserved
@@ -38,7 +41,7 @@ function getWiiUSupportCodeInfo(supportCode) {
 		return;
 	}
 
-	const code = mod.codes[descriptionId];
+	const code = localeJSON.wiiu[moduleId][descriptionId];
 
 	const embed = new Discord.EmbedBuilder();
 	embed.setColor(0x009AC7);
@@ -92,7 +95,7 @@ function getWiiUSupportCodeInfo(supportCode) {
 	return embed;
 }
 
-function get3DSSupportCodeInfo(supportCode) {
+function get3DSSupportCodeInfo(supportCode, localeJSON) {
 	const [moduleId, descriptionId] = supportCode.split('-');
 
 	const mod = threeDSSupportCodes[moduleId]; // * `module` is reserved
@@ -101,7 +104,7 @@ function get3DSSupportCodeInfo(supportCode) {
 		return;
 	}
 
-	const code = mod.codes[descriptionId];
+	const code = localeJSON.3ds[moduleId][descriptionId];
 
 	const embed = new Discord.EmbedBuilder();
 	embed.setColor(0xD12228);
@@ -155,7 +158,7 @@ function get3DSSupportCodeInfo(supportCode) {
 	return embed;
 }
 
-function getPretendoSupportCodeInfo(supportCode) {
+function getPretendoSupportCodeInfo(supportCode, localeJSON) {
 	const [moduleId, descriptionId] = supportCode.split('-');
 
 	const mod = pretendoSupportCodes[moduleId]; // * `module` is reserved
@@ -194,7 +197,7 @@ function getPretendoSupportCodeInfo(supportCode) {
 		return;
 	}
 
-	const code = mod.codes[codeId];
+	const code = localeJSON.pretendo[moduleId][codeId];
 
 	const embed = new Discord.EmbedBuilder();
 	embed.setColor(0x131733);


### PR DESCRIPTION
# CURRENTLY WIP TODO:
- Fill up en-US with all of the Wii U, Pretendo, and 3DS errors.
- Remove previous-now unused error codes.
- Add Weblate integration.

## FEATURES:
- Detects member's Discord locale.
- Updates Bandwidth's text to that locale's language respectively.
- Allows for streamlined editing via JSON.