### PR TITLE
Rename "Warn Piracy" to "Report Piracy"

### DIFF
--- a/src/context-menus/message/warn-piracy.js
+++ b/src/context-menus/message/warn-piracy.js
@@ -103,12 +103,12 @@ async function warnPiracyHandler(interaction) {
 const contextMenu = new ContextMenuCommandBuilder();
 
 contextMenu.setDefaultMemberPermissions(Discord.PermissionFlagsBits.SendMessages);
-contextMenu.setName('Warn Piracy');
+contextMenu.setName('Report Piracy');
 contextMenu.setType(ApplicationCommandType.Message);
 
 module.exports = {
 	name: contextMenu.name,
-	help: 'Flag a message as relating to piracy. This action will be recorded with the information about yourself and the author of the message to prevent abuse.\n```\nUsage: Right click a message and navigate to \'Apps > Warn Piracy\'\n```',
+	help: 'Flag a message as relating to piracy. This action will be recorded with the information about yourself and the author of the message to prevent abuse.\n```\nUsage: Right click a message and navigate to \'Apps > Report Piracy\'\n```',
 	handler: warnPiracyHandler,
 	deploy: contextMenu.toJSON()
 };

--- a/src/context-menus/message/warn-piracy.js
+++ b/src/context-menus/message/warn-piracy.js
@@ -64,7 +64,7 @@ async function warnPiracyHandler(interaction) {
 		},
 		{
 			name: 'Reason',
-			value: 'Piracy Warning',
+			value: 'Piracy',
 			inline: true
 		},
 		{

--- a/src/context-menus/message/warn-piracy.js
+++ b/src/context-menus/message/warn-piracy.js
@@ -19,7 +19,7 @@ async function warnPiracyHandler(interaction) {
 	const warnPiracyEmbed = new Discord.EmbedBuilder();
 	warnPiracyEmbed.setColor(0xF36F8A);
 	warnPiracyEmbed.setThumbnail('attachment://piracy.png');
-	warnPiracyEmbed.setTitle('Piracy Warning');
+	warnPiracyEmbed.setTitle('Potential Piracy Reported');
 	warnPiracyEmbed.setDescription('A user has reported this message as pertaining to piracy. Pretendo Network does not support piracy of any kind. Talking about piracy is prohibited. This includes, but is not limited to:\n\n- Sharing game/firmware dumps\n- Sharing console SDK (software development kit) leaks/tools\n- Sharing tools used to acquire pirated content (cdn downloads, warez sites, etc)\n\n_This action has been logged. If you believe this to have been done unfairly please contact a staff member_');
 
 	const message = await interaction.channel.messages.fetch(interaction.targetId);
@@ -103,7 +103,7 @@ async function warnPiracyHandler(interaction) {
 const contextMenu = new ContextMenuCommandBuilder();
 
 contextMenu.setDefaultMemberPermissions(Discord.PermissionFlagsBits.SendMessages);
-contextMenu.setName('Potential Piracy Reported');
+contextMenu.setName('Report Piracy');
 contextMenu.setType(ApplicationCommandType.Message);
 
 module.exports = {

--- a/src/context-menus/message/warn-piracy.js
+++ b/src/context-menus/message/warn-piracy.js
@@ -103,12 +103,12 @@ async function warnPiracyHandler(interaction) {
 const contextMenu = new ContextMenuCommandBuilder();
 
 contextMenu.setDefaultMemberPermissions(Discord.PermissionFlagsBits.SendMessages);
-contextMenu.setName('Report Piracy');
+contextMenu.setName('Potential Piracy Reported');
 contextMenu.setType(ApplicationCommandType.Message);
 
 module.exports = {
 	name: contextMenu.name,
-	help: 'Flag a message as relating to piracy. This action will be recorded with the information about yourself and the author of the message to prevent abuse.\n```\nUsage: Right click a message and navigate to \'Apps > Report Piracy\'\n```',
+	help: 'Report a message as relating to piracy. This action will be recorded with the information about yourself and the author of the message to prevent abuse.\n```\nUsage: Right click a message and navigate to \'Apps > Report Piracy\'\n```',
 	handler: warnPiracyHandler,
 	deploy: contextMenu.toJSON()
 };


### PR DESCRIPTION
To cut down on confusion, let's change the label on the button to "Report Piracy" instead. This makes it clear anyone can use this to send a report to Pretendo's dev and mod teams.

Resolves: PretendoNetwork#39

<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Fully changes the wording "Warn Piracy" to "Report Piracy" in the context menus visible to end users, including mods and server members.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.