### PR TITLE
feat: modified error code regex patterns to detect wildcard X

### DIFF
--- a/src/utils/errorCode.js
+++ b/src/utils/errorCode.js
@@ -1,10 +1,9 @@
 const Discord = require('discord.js');
 const errors = require('@pretendonetwork/error-codes');
 
-const WIIU_SUPPORT_CODE_REGEX = /(\b1\d{2}-\d{4}\b)/gm;
-const THREE_DS_SUPPORT_CODE_REGEX = /(\b0\d{2}-\d{4}\b)/gm;
-// * There is probably a better way to do this regex
-const PRETENDO_SUPPORT_CODE_REGEX = /(\b678-\d{4}\b|\b598-\d{4}\b|\b727-\d{4}\b)/gm; // * 678 = Martini, 598 = Juxtaposition, 727 = PNID Account
+const WIIU_SUPPORT_CODE_REGEX = /(\b1\d{2}-(?:\d|X){4}\b)/gm;
+const THREE_DS_SUPPORT_CODE_REGEX = /(\b0\d{2}-(?:\d|X){4}\b)/gm;
+const PRETENDO_SUPPORT_CODE_REGEX = /(\b(?:678|598|727)-(?:\d|X){4}\b)/gm; // * 678 = Martini, 598 = Juxtaposition, 727 = PNID Account
 
 /**
  *


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #45

### Changes:

Regex patterns for 3DS/Wii U/Pretendo error codes were changed to detect 'X' inside the message.

Notice: This PR partially resolves the issue #45 by making Bandwidth to detect 'X' inside the message. To actually make Bandwidth/Website treat X as 'any digit', another issue on PretendoNetwork/error-codes will be open.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.