### PR TITLE
fix: treat X/x as wildcard digit in error code regex patterns

### DIFF
--- a/src/utils/errorCode.js
+++ b/src/utils/errorCode.js
@@ -1,13 +1,12 @@
 const Discord = require('discord.js');
 const errors = require('@pretendonetwork/error-codes');
 
-const WIIU_SUPPORT_CODE_REGEX = /(\b1\d{2}-\d{4}\b)/gm;
-const THREE_DS_SUPPORT_CODE_REGEX = /(\b0\d{2}-\d{4}\b)/gm;
+const WIIU_SUPPORT_CODE_REGEX = /(\b1[\dXx]{2}-[\dXx]{4}\b)/gm;
+const THREE_DS_SUPPORT_CODE_REGEX = /(\b0[\dXx]{2}-[\dXx]{4}\b)/gm;
 // * There is probably a better way to do this regex
-const PRETENDO_SUPPORT_CODE_REGEX = /(\b678-\d{4}\b|\b598-\d{4}\b|\b727-\d{4}\b)/gm; // * 678 = Martini, 598 = Juxtaposition, 727 = PNID Account
+const PRETENDO_SUPPORT_CODE_REGEX = /(\b678-[\dXx]{4}\b|\b598-[\dXx]{4}\b|\b727-[\dXx]{4}\b)/gm; // * 678 = Martini, 598 = Juxtaposition, 727 = PNID Account
 
 /**
- *
  * @param {String}} message
  */
 function checkForErrorCode(text) {


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.